### PR TITLE
feat: set gestureHandling as greedy so that user can pan the map usin…

### DIFF
--- a/packages/google_maps_flutter/google_maps_flutter_web/lib/src/convert.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/lib/src/convert.dart
@@ -74,7 +74,7 @@ gmaps.MapOptions _configurationAndStyleToGmapsOptions(
       configuration.zoomGesturesEnabled == false) {
     options.gestureHandling = 'none';
   } else {
-    options.gestureHandling = 'auto';
+    options.gestureHandling = 'greedy';
   }
 
   // These don't have any configuration entries, but they seem to be off in the


### PR DESCRIPTION
Currently user can't pan the flutter google maps web around using one finger, need to set the gestureHandling to 'greedy' to be able to have this behaviour